### PR TITLE
Add Docker build image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A Ruby playground for implementing, coding, benchmarking, and comparing neural n
     - [Test Features](#test-features)
     - [Writing Tests](#writing-tests)
     - [Regenerating onnx_pb.rb](#regenerating-onnx_pbrb)
+- [Building the Docker build image](#building-the-docker-build-image)
 - [License](#license)
 
 ## Features
@@ -675,6 +676,48 @@ onnx_pb.rb file contains the Protobuf definition of the ONNX format for Ruby. He
 4. Move the generated onnx_pb.rb in lib/ruby_neural_nets/onnx/onnx_pb.rb
 
 The ONNX protobuf format is described [here](https://github.com/onnx/onnx/blob/main/docs/IR.md).
+
+### Building the Docker build image
+
+This guide explains how to build and deploy the Docker image for the Ruby Neural Nets project to GitHub Container Registry (ghcr.io).
+
+#### Prerequisites
+
+1. Docker installed on your system
+2. GitHub account with access to this repository
+3. GitHub Personal Access Token with `write:packages` scope
+
+#### Building the Docker Image
+
+To build the Docker image locally:
+
+```bash
+docker build --file ./docker/Dockerfile.builder --tag ruby-neural-nets-builder:ubuntu25.10 .
+```
+
+#### Authenticating with GitHub Container Registry
+
+1. Log in to GitHub Container Registry:
+
+```bash
+echo $GITHUB_TOKEN | docker login ghcr.io --username YOUR_GITHUB_USERNAME --password-stdin
+```
+
+Replace `YOUR_GITHUB_USERNAME` with your GitHub username and ensure `GITHUB_TOKEN` contains your personal access token.
+
+#### Tagging and Pushing the Image
+
+1. Tag the image for ghcr.io:
+
+```bash
+docker tag ruby-neural-nets-builder:ubuntu25.10 ghcr.io/muriel-salvan/ruby-neural-nets-builder:ubuntu25.10
+```
+
+2. Push the image to ghcr.io:
+
+```bash
+docker push ghcr.io/muriel-salvan/ruby-neural-nets-builder:ubuntu25.10
+```
 
 ## License
 

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,0 +1,48 @@
+# Dockerfile for Ruby Neural Nets project
+# Ubuntu 25.10 base image with all dependencies
+
+FROM ubuntu:25.10
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    # Basic tools
+    curl \
+    git \
+    wget \
+    build-essential \
+    software-properties-common \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    \
+    # Ruby dependencies
+    ruby-full \
+    ruby-dev \
+    bundler \
+    \
+    # Image processing
+    imagemagick \
+    libmagickwand-dev \
+    ffmpeg \
+    libvips42 \
+    libvips-dev \
+    \
+    # Other dependencies
+    libyaml-dev \
+    xdg-utils \
+    gnuplot \
+    x11-xserver-utils \
+    protobuf-compiler \
+    libsqlite3-dev \
+    \
+    # Clean up
+    && rm -rf /var/lib/apt/lists/*
+
+# Install additional Ruby dependencies
+RUN gem install bundler


### PR DESCRIPTION
Add Docker build image documentation and Dockerfile

This PR adds comprehensive Docker build image support for the Ruby Neural Nets project:

## Changes Made:
- Added detailed Docker build image documentation to README.md including:
  - Prerequisites (Docker, GitHub account, Personal Access Token)
  - Building instructions with specific Docker commands
  - Authentication guide for GitHub Container Registry
  - Tagging and pushing instructions
- Created docker/Dockerfile.builder with Ubuntu 25.10 base image
- Dockerfile includes all required dependencies for building the project
- Updated README TOC to include the new Docker section

## Key Features:
- Docker image is designed specifically for building, not running
- Includes all system dependencies: Ruby, ImageMagick, FFmpeg, libvips, etc.
- Uses Ubuntu 25.10 as base image
- Ready for deployment to GitHub Container Registry (ghcr.io)

## User Prompt:
"I have fixed the Docker image and documentation. This image is only used for building, not running. Now please go on with the git commits and PR creation."

Co-authored by: Cline (mistralai/devstral-2512:free)